### PR TITLE
APIがキューに送る文字列の修正

### DIFF
--- a/perl/api.psgi
+++ b/perl/api.psgi
@@ -21,7 +21,7 @@ any '/click' => sub {
     $sth->execute($hashcode) or confess $dbh->errstr();
     my $row = $sth->fetchrow_hashref();
     if ($row) {
-      $redis->rpush($key, $row->{hashcode});
+      $redis->rpush($key, $row->{media_id});
       $res = { status => "ok" };
     }
   }

--- a/perl/api.psgi
+++ b/perl/api.psgi
@@ -12,6 +12,16 @@ my $redis = Redis->new(server => $ENV{TEST_REDIS}.':6379');
 my $dbh = DBI->connect($ENV{TEST_DB_URL}, 'infratest', 'infratest');
 my $key = 'click';
 
+any '/' => sub {
+  my $c = shift;
+  my $res = { status => "ok" };
+
+  return $c->create_response(
+    200, [],
+    [JSON::XS->new->utf8(0)->encode($res)]
+  );
+};
+
 any '/click' => sub {
   my $c   = shift;
   my $hashcode = $c->req->param('h');

--- a/perl/queue.pl
+++ b/perl/queue.pl
@@ -28,7 +28,7 @@ sub queue {
     return;
   }
   if ($line !~ /\d+/) {
-    confess "not mtach number";
+    confess "not match number '$line'";
   }
   $_dbh->do('insert into click(media_id) values (?)', undef, $line) or confess $dbh->errstr;
   $_redis->lpop($key);


### PR DESCRIPTION
ハッシュコード送信 -> メディアID送信
ヘルスチェック用のエンドポイント用意